### PR TITLE
resolved_title / state argument for pocket_egt

### DIFF
--- a/man/pocket_get.Rd
+++ b/man/pocket_get.Rd
@@ -8,6 +8,7 @@ pocket_get(
   favorite = NULL,
   item_type = NULL,
   tag = NULL,
+  state = "all",
   consumer_key = Sys.getenv("POCKET_CONSUMER_KEY"),
   access_token = Sys.getenv("POCKET_ACCESS_TOKEN")
 )
@@ -18,6 +19,8 @@ pocket_get(
 \item{item_type}{character. Default NULL. Allows to filter for content type of items. Valid values are: "image", "article", "video". Please note that there might be Pocket items that do not belong to any of those types. The Pocket API documentation only mentions those three.}
 
 \item{tag}{character. Default NULL. Only one tag can be filtered at a time. Set to '_untagged_' if you only want to get untagged items.}
+
+\item{state}{character. Default "all". Allows to filter on unread/archived items or return all. Valid values are "unread", "archive", "all".}
 
 \item{consumer_key}{character. Your Pocket consumer key. Defaults to Sys.getenv("POCKET_CONSUMER_KEY").}
 

--- a/tests/testthat/test_pocket_get.R
+++ b/tests/testthat/test_pocket_get.R
@@ -45,6 +45,25 @@ test_that("invalid item_type value causes error", {
   )
 })
 
+##
+
+test_that("invalid state value causes error", {
+  expect_error(pocket_get(access_token = POCKET_TEST_ACCESS_TOKEN, consumer_key = POCKET_TEST_CONSUMER_KEY, state = c("more", "than", "one")),
+               regexp = "^The state argument can only be one of the following:"
+  )
+
+  test_that("invalid state value causes error", {
+    expect_error(pocket_get(
+      access_token = POCKET_TEST_ACCESS_TOKEN, consumer_key = POCKET_TEST_CONSUMER_KEY,
+      state = "stringisnotvalid"
+    ),
+    regexp = "^The state argument can only be one of the following:"
+    )
+  })
+})
+
+##
+
 # get-86fba0-POST.R
 with_mock_api({
   test_that("invalid access token causes error", {


### PR DESCRIPTION
pocket_get() has a new state argument that allows to filter specifically on unread / archived items.
resolved_title is added to the pocket_get() output.

Closes #33 and #34 